### PR TITLE
feat: support alternative centos distributions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -50,7 +50,7 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "pip3 install --user -r requirements.txt",
-	"postCreateCommand": "poetry install; poetry run pre-commit install --install-hooks",
+	"postCreateCommand": "make dev-install; pip3 install projector-installer --user",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,12 @@ jobs:
           # apt update: "The repository 'http://archive.ubuntu.com/ubuntu groovy Release' does not have a Release file"
           # - ghcr.io/artis3n/docker-ubuntu2010-ansible:latest
           - geerlingguy/docker-ubuntu2004-ansible:latest
-          # Centos 8 reached EOL on Dec 31, 2021
-          # Failed to download metadata for repo 'appstream': Yum repo downloading error: Downloading error(s): repodata/75e00d390273f65b94d63a5ac7db2677d832bfa95b3d7eecf651c6f45e33f8ff-modules.yaml.xz - Cannot download, all mirrors were already tried without success
-          # - geerlingguy/docker-centos8-ansible:latest
-          - geerlingguy/docker-centos7-ansible:python3
+          - geerlingguy/docker-rockylinux8-ansible:latest
+          - ghcr.io/artis3n/docker-almalinux8-ansible:latest
+          - geerlingguy/docker-centos8-ansible:latest
+          # Python 3 sucks on Centos 7, and is a requirement for this role.
+          # We'll continue to support Centos 7 if issues are reported to the repo.
+          # - geerlingguy/docker-centos7-ansible:python3
           - ghcr.io/artis3n/docker-amazonlinux2-ansible:latest
           - ghcr.io/artis3n/docker-debian11-ansible:latest
           - geerlingguy/docker-debian10-ansible:latest

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@
 This role installs and configures [Jetbrains Projector](https://lp.jetbrains.com/projector/) IDEs leveraging Jetbrains' [projector-installer](https://github.com/JetBrains/projector-installer) command.
 
 Supported operating systems:
-- Ubuntu
-- Debian
+- Debian / Ubuntu
 - CentOS / RedHat
+- Rocky Linux / AlmaLinux
 - Amazon Linux 2
+- Raspbian (untested but should work through Debian support)
 
 Note: While Projector and Jetbrains IDEs support ARM servers, the two together are "not well tested" by Jetbrains, so you may experience [issues](https://youtrack.jetbrains.com/issue/PRJ-160) running IDEs on ARM, which are outside the scope of this role.
 

--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -25,13 +25,13 @@
     (ansible_distribution == 'CentOS' and ansible_distribution_major_version < '8')
     or ansible_distribution == 'Amazon'
   block:
-    - name: Install Dependencies
+    - name: Install Legacy Dependencies
       become: true
       ansible.builtin.yum:
         name: '{{ yum_dependencies + centos7_dependencies }}'
         state: present
 
-    - name: Install Pip Dependencies
+    - name: Install Legacy Pip Dependencies
       ansible.builtin.pip:
         name: pexpect
 
@@ -41,7 +41,10 @@
     name: '{{ yum_dependencies + centos_modern_dependencies }}'
     state: present
   when: >
-    ansible_distribution == 'CentOS' and ansible_distribution_major_version >= '8'
+    not (
+    (ansible_distribution == 'CentOS' and ansible_distribution_major_version < '8')
+    or ansible_distribution == 'Amazon'
+    )
 
 - name: Install Java Corretto JRE
   become: true

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -53,3 +53,7 @@ debian_family:
 centos_family:
   - Amazon
   - CentOS
+  - Rocky
+  - AlmaLinux
+  - OracleLinux
+  - RedHat


### PR DESCRIPTION
- chore: drop centos 7 from CI suite. Best attempt at support will continue
- chore: add centos 8 back into the CI suite
- feat: add rocky linux support
- feat: add almalinux support